### PR TITLE
Configurable path for prime core

### DIFF
--- a/packages/prime-core/src/server.ts
+++ b/packages/prime-core/src/server.ts
@@ -50,7 +50,7 @@ export const createServer = async ({ port, connection }: ServerConfig) => {
 
     if (config.sofaApi) {
       app.use(
-        '/api',
+        `${config.path}api`,
         sofa({
           schema: external.schema,
           ignore: ['Prime_Document'],
@@ -63,13 +63,15 @@ export const createServer = async ({ port, connection }: ServerConfig) => {
 
   externalServer.applyMiddleware({
     app,
+    path: `${config.path}graphql`,
     cors: {
       origin: true,
     },
   });
 
   fields.forEach(
-    field => field.ui && app.use(`/prime/field/${field.type}`, express.static(field.ui))
+    field =>
+      field.ui && app.use(`${config.pathClean}/prime/field/${field.type}`, express.static(field.ui))
   );
 
   const apollo = new ApolloServer({
@@ -95,14 +97,14 @@ export const createServer = async ({ port, connection }: ServerConfig) => {
   apollo.installSubscriptionHandlers(server);
   apollo.applyMiddleware({
     app,
-    path: '/prime/graphql',
+    path: `${config.path}prime/graphql`,
     cors: {
       origin: true,
     },
   });
 
   previewRoutes(app);
-  serveUI(app, config);
+  serveUI(app);
 
   return server.listen(port, () => {
     log(`🚀 Server ready at http://localhost:${port}${apollo.graphqlPath}`);

--- a/packages/prime-core/src/utils/config.ts
+++ b/packages/prime-core/src/utils/config.ts
@@ -17,7 +17,12 @@ export const config = rc('prime', {
   sofaApi: true,
   uiDir: defaultUiDir(),
   coreUrl: defaultCoreUrl(),
+  path: defaultCorePath(),
 });
+
+config.coreUrl = config.coreUrl.trim().replace(/\/+$/, '');
+config.path = `/${config.path.trim()}/`.replace(/\/+$/, '/').replace(/^\/+/, '/');
+config.pathClean = config.path.replace(/\/+$/, '');
 
 function defaultUiDir() {
   try {
@@ -46,4 +51,16 @@ function defaultCoreUrl() {
   }
 
   return `http://localhost:${PORT || 4000}`;
+}
+
+function defaultCorePath() {
+  const { CORE_PATH } = process.env;
+  if (CORE_PATH) {
+    return CORE_PATH;
+  }
+  const matches = defaultCoreUrl().match(/[0-9a-zA-Z]\/(.*)$/);
+  if (matches && matches[1]) {
+    return matches[1];
+  }
+  return '/';
 }

--- a/packages/prime-core/src/utils/preview.ts
+++ b/packages/prime-core/src/utils/preview.ts
@@ -2,10 +2,11 @@ import express from 'express';
 import { getRepository } from 'typeorm';
 import { Document } from '../entities/Document';
 import { Schema } from '../entities/Schema';
+import { config } from './config';
 import { DocumentTransformer } from './DocumentTransformer';
 
 export const previewRoutes = (app: express.Application) => {
-  app.get('/prime/redirect', (req, res) => {
+  app.get(`${config.pathClean}/prime/redirect`, (req, res) => {
     const { id, url, accessToken, refreshToken } = req.query;
     if (id.length === 36) {
       const cookieConfig = {
@@ -22,7 +23,7 @@ export const previewRoutes = (app: express.Application) => {
     res.json({ success: false });
   });
 
-  app.get('/prime/preview', async (req, res) => {
+  app.get(`${config.pathClean}/prime/preview`, async (req, res) => {
     const cookie = String(req.headers.cookie);
     const cookies = cookie.split(';').reduce((acc, item) => {
       const [key, value] = item

--- a/packages/prime-core/src/utils/serveUI.ts
+++ b/packages/prime-core/src/utils/serveUI.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
+import { config } from './config';
 import { log } from './log';
 
-export const serveUI = (app: express.Application, config) => {
+export const serveUI = (app: express.Application) => {
   const { uiDir } = config;
 
   if (!uiDir) {
@@ -11,13 +12,14 @@ export const serveUI = (app: express.Application, config) => {
   }
 
   app.use(
+    config.pathClean,
     express.static(uiDir, {
       index: false,
     })
   );
 
-  app.get('*', (req, res, next) => {
-    if (req.url.substr(0, 4) === '/api') {
+  app.get(`${config.pathClean}*`, (req, res, next) => {
+    if (req.url.substr(config.path.length, 4) === '/api') {
       return next();
     }
 
@@ -26,7 +28,12 @@ export const serveUI = (app: express.Application, config) => {
         log(err);
         res.send('error');
       } else {
-        res.send(data.toString().replace('"$PRIME_CONFIG$"', `'${JSON.stringify(config)}'`));
+        res.send(
+          data
+            .toString()
+            .replace('"$PRIME_CONFIG$"', `'${JSON.stringify(config)}'`)
+            .replace(/\/static\//g, `${config.path}static/`)
+        );
       }
     });
   });

--- a/packages/prime-ui/src/App.tsx
+++ b/packages/prime-ui/src/App.tsx
@@ -12,7 +12,7 @@ import { ResetPassword } from './routes/reset-password/ResetPassword';
 import { Schemas } from './routes/schemas/Schemas';
 import { Settings } from './routes/settings/Settings';
 import { Auth } from './stores/auth';
-import { ContentTypes } from './stores/contentTypes';
+import { Settings as CSettings } from './stores/settings';
 
 const Private = observer(({ children }) => {
   if (Auth.isLoggedIn) {
@@ -38,7 +38,7 @@ export class App extends React.Component {
     }
 
     return (
-      <BrowserRouter>
+      <BrowserRouter basename={CSettings.path}>
         <Route
           render={({ location }) => {
             let key = location.pathname;

--- a/packages/prime-ui/src/stores/settings.ts
+++ b/packages/prime-ui/src/stores/settings.ts
@@ -8,12 +8,14 @@ const isProd = process.env.NODE_ENV === 'production';
 
 let config = get(window, 'prime.config', '');
 let coreUrl = isProd ? '/' : 'http://localhost:4000';
+let corePath = '';
 const fields: any = [];
 let env: any = {};
 
 try {
   config = JSON.parse(config);
   coreUrl = config.coreUrl || coreUrl;
+  corePath = config.path || '';
   env = config.env || env;
 } catch (err) {
   if (isProd) {
@@ -65,6 +67,7 @@ export const Settings = types
   .model('Settings', {
     isProd,
     coreUrl,
+    path: corePath,
     packages: types.array(PackageVersion),
     shouldReloadPlayground: false,
     env: types.frozen(),


### PR DESCRIPTION
```
CORE_URL=http://localhost:4000/cms
```
> Will have UI connect to `http://localhost:4000/cms` and serve Core at `/cms`.

```
CORE_URL=http://localhost:4000/cms
CORE_PATH=other
```
> Will have UI connect to `http://localhost:4000/cms` but serve Core at `/other`.


So if you don't configure CORE_PATH it will derive from CORE_URL.