### PR TITLE
fix: not being able to delete schema (#180)

### DIFF
--- a/packages/prime-core/src/modules/internal/resolvers/SchemaResolver.ts
+++ b/packages/prime-core/src/modules/internal/resolvers/SchemaResolver.ts
@@ -114,7 +114,7 @@ export class SchemaResolver {
     await this.documentRepository.update(
       { schemaId: id },
       {
-        deletedAt: Date.now(),
+        deletedAt: new Date(),
       }
     );
     await this.schemaRepository.remove(schema);


### PR DESCRIPTION
`Date.now()` was returning the incorrect format expected by the db, using `new Date()` allows the ORM to coerce to whatever format it needs