### PR TITLE
Fix "Cannot redefine property: snapshot" error

### DIFF
--- a/packages/prime-core/src/modules/internal/resolvers/SchemaResolver.ts
+++ b/packages/prime-core/src/modules/internal/resolvers/SchemaResolver.ts
@@ -114,7 +114,7 @@ export class SchemaResolver {
     await this.documentRepository.update(
       { schemaId: id },
       {
-        deletedAt: Date.now(),
+        deletedAt: new Date(),
       }
     );
     await this.schemaRepository.remove(schema);

--- a/packages/prime-ui/package.json
+++ b/packages/prime-ui/package.json
@@ -57,7 +57,7 @@
     "mobx": "5.9.4",
     "mobx-devtools-mst": "0.9.21",
     "mobx-react": "5.4.3",
-    "mobx-state-tree": "3.7.1",
+    "mobx-state-tree": "3.10.1",
     "moment": "2.24.0",
     "rc": "1.2.8",
     "react": "16.8.0-alpha.1",

--- a/packages/prime-ui/src/routes/documents/DocumentsDetail.tsx
+++ b/packages/prime-ui/src/routes/documents/DocumentsDetail.tsx
@@ -49,7 +49,7 @@ interface IOptions {
 export class DocumentsDetail extends React.Component<IProps> {
   public documentForm: BaseDocumentForm | null = null;
 
-  public contentEntry: Instance<typeof ContentEntry> | null = null;
+  public contentEntry: Instance<typeof ContentEntry> | undefined | null = null;
   public contentType: Instance<typeof ContentType> | undefined;
   public locale = Settings.masterLocale;
 

--- a/packages/prime-ui/src/routes/schemas/SchemaDetail.tsx
+++ b/packages/prime-ui/src/routes/schemas/SchemaDetail.tsx
@@ -82,8 +82,10 @@ export class SchemaDetail extends React.Component<IProps> {
 
   public async load() {
     this.loading = true;
-    this.contentType = clone(await ContentTypes.loadById(this.props.match.params.id));
-    if (this.contentType) {
+    const contentType = await ContentTypes.loadById(this.props.match.params.id);
+
+    if (contentType) {
+      this.contentType = clone(contentType);
       this.selectedGroup = this.contentType.groups[0] || DEFAULT_GROUP_TITLE;
       const { data } = await client.query({ query: ALL_FIELDS });
       this.availableFields = (data as any).allFields;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11644,10 +11644,10 @@ mobx-react@5.4.3:
     hoist-non-react-statics "^3.0.0"
     react-lifecycles-compat "^3.0.2"
 
-mobx-state-tree@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-3.7.1.tgz#161fc1b46224d3defa28b482914d3aa8e1b80ed7"
-  integrity sha512-XJHT4ldB2eoHBOqTsNLOsJHNsClSkAUwNWQm9njat28Md0ymQIpVPpcKywz9I8tbu2RoWlEm1/U4v6SeQEk/sA==
+mobx-state-tree@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-3.10.1.tgz#79aea97360f36cc6eedd488baacbe47f10d07aa1"
+  integrity sha512-jP/0Fy9rmFJoVHLYTjhvKVHl9MhtRQ/a73NzsmD60wiosSrxzqFqi+p1zdf2g8dqW7ihUYfmV6hRC4+nhh6Rgg==
 
 mobx@5.9.4:
   version "5.9.4"


### PR DESCRIPTION
Kept getting this error when browsing schemas, the fix was to update Mobx State Tree.

Note that some of the types changed in the process of this, but nothing major.