### PR TITLE
fix(core): show require errors rather than swallow

### DIFF
--- a/packages/prime-core/src/utils/fields.ts
+++ b/packages/prime-core/src/utils/fields.ts
@@ -55,7 +55,7 @@ export const fields = (config.fields || [])
 
       return field;
     } catch (err) {
-      log('Could not resolve field module %o', moduleName);
+      log('Could not resolve field module %o because:\n%O', moduleName, err);
     }
 
     return null;


### PR DESCRIPTION
This one caused me hours and hours of ripping my hair out :)

Was trying to make a couple of changes to my `field-richtext` PR and it just said that it couldn't resolve it. I was sure that it had something to do with the `ts-node-dev` changes so was trying to roll it back. Then after reseting those changes it STILL wouldn't work... so I started to blame lerna, yarn linking and node resolves in general. WHY DID IT JUST STOP WORKING?!

Then I found that core contains a utils function for loading the fields dynamically and added some logs there to look into it. Then I realised that if I stash my changes, it works after a compile but with the changes there's no error whatsoever apart from: `cannot resolve @primecms/field-richtext`.

After adding the changes in this PR the real error presents itself:
<img width="1178" alt="Screenshot 2019-05-20 18 18 39" src="https://user-images.githubusercontent.com/1162531/58014549-b4e18700-7b2b-11e9-933b-c7c08bf9dd0d.png">

If the required module doesn't exist at all, it's still much more informative:
<img width="959" alt="Screenshot 2019-05-20 18 20 24" src="https://user-images.githubusercontent.com/1162531/58014671-f40fd800-7b2b-11e9-93e6-f9056ec6ffcc.png">

Here's an example of a module that works and one that fails at runtime on compile (hint, there's no way to know):
<img width="653" alt="Screenshot 2019-05-20 17 50 51" src="https://user-images.githubusercontent.com/1162531/58014939-97f98380-7b2c-11e9-8858-ab3cd07d4a5e.png">
