### PR TITLE
feat(query): add possibility to filter query by subdocuments id

### DIFF
--- a/packages/prime-core/src/modules/external/utils/documentWhereBuilder.ts
+++ b/packages/prime-core/src/modules/external/utils/documentWhereBuilder.ts
@@ -26,6 +26,7 @@ const operators = {
   in: 'IN',
   contains: 'LIKE',
   not: '!=',
+  id: 'SIMILAR TO',
 };
 
 const modes = { OR: 'orWhere', AND: 'andWhere' };
@@ -59,6 +60,8 @@ export const documentWhereBuilder = (
       let value = whereOrValue;
       if (fieldName === 'contains') {
         value = `%${value}%`;
+      } else if (fieldName === 'id') {
+        value = `%(,${value}("|\\Z))%`;
       }
       const key = Buffer.from(value).toString('hex');
       queryBuilder[mode](`${column} ${operator} :${key}`, { [key]: value });

--- a/packages/prime-field-document/__tests__/index.ts
+++ b/packages/prime-field-document/__tests__/index.ts
@@ -45,8 +45,9 @@ describe('PrimeFieldDocument', () => {
     expect(typeof PrimeFieldDocument).toBe('function');
   });
 
-  it('should have null where type', async () => {
-    expect(await test.whereType(createContext())).toBeNull();
+  it('should have where type', async () => {
+    test = createTestField();
+    expect(await test.whereType(createContext())).toBeTruthy();
   });
 
   it('should have null output type with no options', async () => {

--- a/packages/prime-field-document/src/PrimeFieldDocument.ts
+++ b/packages/prime-field-document/src/PrimeFieldDocument.ts
@@ -1,11 +1,13 @@
 import { PrimeField, PrimeFieldContext } from '@primecms/field';
 import {
   GraphQLID,
+  GraphQLInputObjectType,
   GraphQLList,
   GraphQLObjectType,
   GraphQLString,
   GraphQLUnionType,
 } from 'graphql';
+import { camelCase, upperFirst } from 'lodash';
 
 interface Options {
   schemaIds: string[];
@@ -120,5 +122,14 @@ export class PrimeFieldDocument extends PrimeField {
     return {
       type: options.multiple ? new GraphQLList(GraphQLID) : GraphQLID,
     };
+  }
+
+  public async whereType(context: PrimeFieldContext) {
+    return new GraphQLInputObjectType({
+      name: `${context.name}_${upperFirst(camelCase(this.schemaField.name))}_Where`,
+      fields: {
+        id: { type: GraphQLID },
+      },
+    });
   }
 }


### PR DESCRIPTION
In relation to feature request #133 I've implemented a basic possibility to query documents filtered by its subdocuments ids.