### PR TITLE
fix: add an empty array fallback for fields with multiple documents type

### DIFF
--- a/packages/prime-field-document/src/PrimeFieldDocument.ts
+++ b/packages/prime-field-document/src/PrimeFieldDocument.ts
@@ -76,7 +76,7 @@ export class PrimeFieldDocument extends PrimeField {
           locale: { type: GraphQLString },
         },
         resolve: async (root, args, ctx, info) => {
-          const values = root[this.schemaField.name];
+          const values = root[this.schemaField.name] || [];
           return Promise.all(
             values.map(value => {
               const [schemaId, documentId] = value.split(',');


### PR DESCRIPTION
By an accident I've found a bug which was causing a query to fail. When you create a field with a type of multiple documents and then publish a post without any value added it will fail on trying to access map method on null value. The fix was to simply provide an empty array fallback in `PrimeFieldDocument` class.