### PR TITLE
WIP fix(field-slice): #245 normalise slice and group repeat option

### DIFF
--- a/packages/prime-core/src/utils/DocumentTransformer.ts
+++ b/packages/prime-core/src/utils/DocumentTransformer.ts
@@ -95,7 +95,11 @@ export class DocumentTransformer {
       }
 
       if (field.type === 'slice') {
-        if (options.multiple && Array.isArray(value)) {
+        if (!options.multiple && Array.isArray(value)) {
+          value = [value.shift()];
+        }
+
+        if (Array.isArray(value)) {
           value = (await Promise.all(
             value.map(async item => {
               const sfields = await this.getFields({ id: item.__inputname } as any);

--- a/packages/prime-field-slice/src/PrimeFieldSlice.ts
+++ b/packages/prime-field-slice/src/PrimeFieldSlice.ts
@@ -72,13 +72,9 @@ export class PrimeFieldSlice extends PrimeField {
       resolveType,
     });
 
-    if (this.options.multiple) {
-      return {
-        type: new GraphQLList(SlicesUnionType),
-      };
-    }
-
-    return { type: SlicesUnionType };
+    return {
+      type: new GraphQLList(SlicesUnionType),
+    };
   }
 
   public inputType(


### PR DESCRIPTION
This PR addresses #245 and #244 

1. PrimeFieldSlice outputType should always return an array of SlicesUnionType.
2. We handle slice value transform in a similar manner to groups processOutput method.

Tests incoming...