### PR TITLE
docs(contributing): add yarn compile as a step before start fixes #211

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,9 @@ All pull requests and issues are welcome
 
 - Install project dependencies: `yarn`
 - Link together all the packages: `yarn setup`
-- Watch the packages for changes and recompile: `yarn start`
+- Compile all the packages (**needed** once): `yarn compile`
+- Watch the **prime-core** and **prime-ui** packages for changes and recompile: `yarn start`
+- Reset the repository to a clean state and re-install everything: `yarn reset`
 
 ## Pull Requests
 


### PR DESCRIPTION
fixes #211 by improving the sparse contribution docs just a little bit. The better solution would be to have `dev` npm script in all `prime-field*` packages that is running a watcher; however because by default lerna will _wait_ for an npm script to finish before calling the next one, this would imply `--parallel` as an additional switch for the `dev` script and this is prone to race conditions.