### PR TITLE
Fix h1 content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -69,7 +69,7 @@
     <div id="app"></div>
     <script>
       window.$docsify = {
-        name: '<i style="font-family: system; font-size: 46px; color: #4d4d4d;">prime</i>',
+        name: 'prime',
         repo: 'https://github.com/birkir/prime',
         homepage: 'https://raw.githubusercontent.com/birkir/prime/master/README.md',
         loadSidebar: true,


### PR DESCRIPTION
It renders everything inside of the <a>-tag on the deployed version.
<i style="font-family: system; font-size: 46px; color: #4d4d4d;">prime</i>

Now it will render just 'prime', but without the styling.

![image](https://user-images.githubusercontent.com/43420049/73127404-f92cfd00-3fbf-11ea-812a-b7ed2d2f9c0e.png)
