### PR TITLE
fix: update WebhookCalls graphql query to no longer cause a syntax error

### DIFF
--- a/packages/prime-ui/src/routes/settings/WebhookCalls.tsx
+++ b/packages/prime-ui/src/routes/settings/WebhookCalls.tsx
@@ -14,8 +14,8 @@ export const WebhookCalls = ({ match }: any) => (
       variables={{ id: match.params.webhookId }}
       fetchPolicy="network-only"
       query={gql`
-        query Webhook(id:ID!) {
-          Webhook(id:$id) {
+        query Webhook($id: ID!) {
+          Webhook(id: $id) {
             id
             calls {
               id


### PR DESCRIPTION
Currently the WebhookCalls page is broken due to syntax error in the GraphQL query, this quick little fix will resolve the issue and allow the page to be viewed.